### PR TITLE
Summary (build_notify) : avoid printing <null> in the channel

### DIFF
--- a/src/main/java/hudson/plugins/im/build_notify/SummaryOnlyBuildToChatNotifier.java
+++ b/src/main/java/hudson/plugins/im/build_notify/SummaryOnlyBuildToChatNotifier.java
@@ -39,12 +39,21 @@ public class SummaryOnlyBuildToChatNotifier extends BuildToChatNotifier {
             sb = new StringBuilder();
         }
         ResultTrend result = getResultTrend(run);
-        sb.append(Messages.SummaryOnlyBuildToChatNotifier_Summary(
+        String extraMessage = publisher.getExtraMessage();
+        if (extraMessage != null && !extraMessage.equals("")) {
+            sb.append(Messages.SummaryOnlyBuildToChatNotifier_SummaryExtra(
                 getProjectName(run), run.getDisplayName(),
                 result.getID(),
                 run.getTimestampString(),
                 MessageHelper.getBuildURL(run),
-                publisher.getExtraMessage()));
+                extraMessage));
+        } else {
+            sb.append(Messages.SummaryOnlyBuildToChatNotifier_Summary(
+                getProjectName(run), run.getDisplayName(),
+                result.getID(),
+                run.getTimestampString(),
+                MessageHelper.getBuildURL(run)));
+        }
 
         return sb.toString();
     }

--- a/src/main/java/hudson/plugins/im/build_notify/SummaryOnlyBuildToChatNotifier.java
+++ b/src/main/java/hudson/plugins/im/build_notify/SummaryOnlyBuildToChatNotifier.java
@@ -27,7 +27,12 @@ public class SummaryOnlyBuildToChatNotifier extends BuildToChatNotifier {
 
     @Override
     public String buildStartMessage(IMPublisher publisher, AbstractBuild<?, ?> build, BuildListener listener) throws IOException, InterruptedException {
-        return Messages.SummaryOnlyBuildToChatNotifier_StartMessage(build.getDisplayName(),getProjectName(build), publisher.getExtraMessage());
+        String extraMessage = publisher.getExtraMessage();
+        if (extraMessage != null && !extraMessage.equals("")) {
+            return Messages.SummaryOnlyBuildToChatNotifier_StartMessageExtra(build.getDisplayName(),getProjectName(build), extraMessage);
+        } else {
+            return Messages.SummaryOnlyBuildToChatNotifier_StartMessage(build.getDisplayName(),getProjectName(build));
+        }
     }
 
     @Override

--- a/src/main/resources/hudson/plugins/im/build_notify/Messages.properties
+++ b/src/main/resources/hudson/plugins/im/build_notify/Messages.properties
@@ -1,4 +1,5 @@
-SummaryOnlyBuildToChatNotifier.Summary=Project {0} build {1}: {2} in {3}: {4} {5}
+SummaryOnlyBuildToChatNotifier.Summary=Project {0} build {1}: {2} in {3}: {4}
+SummaryOnlyBuildToChatNotifier.SummaryExtra=Project {0} build {1}: {2} in {3}: {4} {5}
 SummaryOnlyBuildToChatNotifier.BuildIsFixed=Yippee, build fixed!\n
 SummaryOnlyBuildToChatNotifier.StartMessage=Starting build {0} for job {1} {2}
 ExtraMessageOnlyBuildToChatNotifier.StartMessage=Starting build {0} for job {1}: {2}

--- a/src/main/resources/hudson/plugins/im/build_notify/Messages.properties
+++ b/src/main/resources/hudson/plugins/im/build_notify/Messages.properties
@@ -1,6 +1,7 @@
 SummaryOnlyBuildToChatNotifier.Summary=Project {0} build {1}: {2} in {3}: {4}
 SummaryOnlyBuildToChatNotifier.SummaryExtra=Project {0} build {1}: {2} in {3}: {4} {5}
 SummaryOnlyBuildToChatNotifier.BuildIsFixed=Yippee, build fixed!\n
-SummaryOnlyBuildToChatNotifier.StartMessage=Starting build {0} for job {1} {2}
+SummaryOnlyBuildToChatNotifier.StartMessage=Starting build {0} for job {1}
+SummaryOnlyBuildToChatNotifier.StartMessageExtra=Starting build {0} for job {1} {2}
 ExtraMessageOnlyBuildToChatNotifier.StartMessage=Starting build {0} for job {1}: {2}
 ExtraMessageOnlyBuildToChatNotifier.Message=Project {0} build {1}: {2}


### PR DESCRIPTION
With this branch applied to our build of the plugin, we get messages like:
````
(16:32:32) jenkins2: (notice) Project build-OVA-image build #5410: STILL FAILING in 21 sec: https://jenkins2/job/build-OVA-image/5410/ null
````

The `null` at the end was not there before the branch merge. So this PR aims to rectify it, posting the newly introduced "extra message" only if one is available.